### PR TITLE
Merging in most recent SML3-related docs updates

### DIFF
--- a/modules/ROOT/pages/Development/BeginnersGuide/SimpleMod/gameworldmodule.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/SimpleMod/gameworldmodule.adoc
@@ -64,7 +64,8 @@ This folder is where you will be putting most of the assets
 ====
 If you want to Open Source your mod,
 or simply want to use a version control system like Git,
-this folder is the ideal place for you to create the repository.
+the mod's plugin folder (containing the `.uplugin file`)
+is the ideal place for you to create the repository.
 
 Using version control is essential for collaborating on a mod with others,
 it helps write patch notes when you release an update,

--- a/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
@@ -9,8 +9,10 @@ This can be a very lengthy process, so if you have to work on something else, ma
 
 [TIP]
 ====
-If you'd prefer a different format of guide, you can find a video guide https://www.youtube.com/watch?v=-HVw6-3Awqs[here].
-**As of SML 3.0.0, these tutorials are partially out of date, but many of the concepts will still carry over.**
+If you'd prefer a different format of guide, you can find a video guide
+https://www.youtube.com/watch?v=-HVw6-3Awqs[here].
+**As of SML 3.0.0, these tutorials are out of date,
+but some of the concepts will still carry over.**
 If you get stuck in the video tutorials, return here and follow these guides instead.
 Be sure to read over the steps here as well to be sure you're doing things correctly.
 ====

--- a/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
@@ -85,20 +85,23 @@ Accept any authentication prompts that appear along the way.
 
 [WARNING]
 ====
-Make sure that you selected the correct version of Wwise. It's easy to choose the wrong version on accident.
+Make sure that you selected the correct version of Wwise.
+It's easy to choose the wrong version on accident.
 ====
 
 == Starter Project
 
-To get started developing your mod, it's best to start off with the Starter Project as a base.
-You can download it from https://github.com/satisfactorymodding/SatisfactoryModLoader/releases[here].
-Download `SML-Shipping-Dev-Win64.zip` or `SML.zip` from the latest release version and unzip it.
+To get started developing your mod, start off with the Starter Project as a base.
+You can find it on the Satisfactory Modding GitHub, or download it directly via 
+https://github.com/satisfactorymodding/SatisfactoryModLoader/archive/refs/heads/master.zip[this link].
+// Download `SML-Shipping-Dev-Win64.zip` or `SML.zip` from the latest release version and unzip it.
 // You can download it via GitHub from https://github.com/satisfactorymodding/SatisfactoryModLoader/archive/refs/heads/sml-dev.zip[here].
 The starter project itself is contained in `FactoryGame.uproject`,
-and this download contains the SML-related plugins already loaded.
+and this download contains the relevant SML-related plugins already loaded.
+After it finishes downloading, you should unzip it.
 
-If you are familiar with version control software,
-we suggest you clone the repo instead,
+If you are familiar with version control software, we suggest you
+https://github.com/satisfactorymodding/SatisfactoryModLoader/[clone the repo instead],
 which simplifies the process of updating your project later.
 Check on the discord to find out which branch to clone,
 although it's most likely `master`.

--- a/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
@@ -88,24 +88,18 @@ Make sure that you selected the correct version of Wwise. It's easy to choose th
 
 == Starter Project
 
-[WARNING]
-====
-SML 3.0 Note: Get the sml-dev branch from
-https://github.com/satisfactorymodding/SatisfactoryModLoader/archive/refs/heads/sml-dev.zip[here]
-instead of using the link below (for now).
-====
-
 To get started developing your mod, it's best to start off with the Starter Project as a base.
-// TODO Bring this link back in once we're out of sml-dev
 You can download it from https://github.com/satisfactorymodding/SatisfactoryModLoader/releases[here].
-Download `SML-Shipping-Dev-Win64.zip` from the latest release version and unzip it.
+Download `SML-Shipping-Dev-Win64.zip` or `SML.zip` from the latest release version and unzip it.
 // You can download it via GitHub from https://github.com/satisfactorymodding/SatisfactoryModLoader/archive/refs/heads/sml-dev.zip[here].
 The starter project itself is contained in `FactoryGame.uproject`,
 and this download contains the SML-related plugins already loaded.
 
 If you are familiar with version control software,
-you may want to clone the repo instead,
+we suggest you clone the repo instead,
 which simplifies the process of updating your project later.
+Check on the discord to find out which branch to clone,
+although it's most likely `master`.
 
 == Satisfactory Mod Loader
 

--- a/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
@@ -86,7 +86,7 @@ Accept any authentication prompts that appear along the way.
 [WARNING]
 ====
 Make sure that you selected the correct version of Wwise.
-It's easy to choose the wrong version on accident.
+It's easy to choose the wrong version by accident.
 ====
 
 == Starter Project

--- a/modules/ROOT/pages/Development/BeginnersGuide/project_setup.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/project_setup.adoc
@@ -28,10 +28,10 @@ If you choose to do this, the plugin folder that you create later
 will serve as your repo folder.
 You may wish to clone the starer project repo as opposed to using the downloaded zip.
 
-You can use this starer project for developing multiple mods,
-since each mod will be its own separate plugin folder within this project.
+You can use this starter project for developing multiple mods at once,
+since each mod will be its own separate Plugin folder within the project.
 
-Feel free to name the extracted `SML-Shipping-Dev-Win64` folder to whatever you like.
+Feel free to rename the extracted `SML-Shipping-Dev-Win64` folder to whatever you like.
 
 == Setting up Wwise
 

--- a/modules/ROOT/pages/Development/BeginnersGuide/project_setup.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/project_setup.adoc
@@ -22,7 +22,7 @@ You should have already downloaded the starter project in the previous steps of 
 This will be the folder that all of your mod's files will be put into,
 so extract the folder somewhere convenient for you where you can find it later,
 such as your Documents folder.
-Of note - keep the directory as short as possible.
+Of note - keep the file path as short as possible.
 When packing Unreal projects, some filenames can get long,
 so a very nested location may cause issues.
 
@@ -121,22 +121,47 @@ Make sure you run the above command from Command Prompt and not Powershell. It i
 
 == Project Compilation
 
-You'll want to compile the project now to ensure it generates correctly.
+Next up is compiling the project from Visual Studio.
+It is possible for Unreal to compile the project as well on launch,
+but if there is an error,
+Unreal will give a very vague report as to what went wrong.
+As such, it's best to just always compile from Visual Studio
+so you don't have to build a second time to see the error report.
 
-Do this by opening the .sln file, make sure you have in the toolbar `Development Editor` and `Win64` selected.
-On the right side in Solution Explorer just right click on
+Open up the the .sln file in your project folder.
+Once Visual Studio loads,
+make sure that you have `Development Editor`
+and `Win64` selected in the top toolbar.
+On the right side in Solution Explorer, right click on
 the `FactoryGame` project and hit `Build`.
 This will take some time; go pet some lizard doggos as you wait.
 You'll know it's done when the little box-with-cubes-piling-into-it
 icon in the blue bar at the bottom of Visual Studio goes away.
-You can monitor its progress from the Output log if desired.
+You can monitor its progress from the Output log window if desired.
 
-This creates the binaries used by the Editor,
-allowing it to interact with the native SML code or native code written by you.
+After it completes, you should select `Shipping` in the toolbar and start another build.
+Building both of these is required for the editor to function correctly,
+and for you to be able to distribute your mod.
 
-When you want to test the mod, make sure to build the project for `Shipping`.
-Without doing so, the editor binaries won't be able to dynamic link with their dependencies,
-and the game will crash.
+[WARNING]
+====
+Some important notes for the future:
+
+After updates to SML that change the editor,
+or your own {cpp} code that changes editor functionality,
+you must close the Editor and rebuild `Development Editor`
+from Visual Studio for the changes to take effect.
+
+When you want to test or release your mod, make sure to build the project for `Shipping`.
+Without doing so, your mod will be missing important files.
+====
+
+If you see errors related to `AkAudio` or similar, you need to go back
+and re-do the Wwise integration step
+
+If you encounter issues during this step, consider asking for help on the Discord.
+
+Now that you've built the binaries, you Editor should open without any issues.
 
 == Open Unreal Editor
 

--- a/modules/ROOT/pages/Development/BeginnersGuide/project_setup.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/project_setup.adoc
@@ -19,7 +19,10 @@ Be sure to read over the steps here as well to be sure you're doing things corre
 
 You should have already downloaded the starter project in the previous steps of the tutorial. Unzip `SML-Shipping-Dev-Win64.zip` (or `SatisfactoryModLoader-sml-dev.zip` of you downloaded a development build) to get the starter project files. If you're having issues extracting the zip, try using another zip extracting software such as 7zip or WinRAR.
 
-This will be the folder that all of your mod's files will be put into, so extract the folder somewhere convenient for you where you can find it later, such as your Documents folder. Of note - keep the directory as short as possible.
+This will be the folder that all of your mod's files will be put into,
+so extract the folder somewhere convenient for you where you can find it later,
+such as your Documents folder.
+Of note - keep the directory as short as possible.
 When packing Unreal projects, some filenames can get long,
 so a very nested location may cause issues.
 
@@ -43,7 +46,9 @@ that looks like errors or warnings but can be safely ignored.
 
 [WARNING]
 ====
-If part of the setup process fails for you, it is most likely this step. If you have errors completing the setup process, come back to here and make sure you followed these steps correctly.
+If part of the setup process fails for you, it is most likely this step.
+If you have errors completing the setup process,
+come back to here and make sure you followed these steps correctly.
 ====
 
 Start the Wwise launcher that you installed earlier and update the launcher if needed.
@@ -66,13 +71,22 @@ If version `2021.1.0.7575` does not appear even after you have selected `All`,
 edit your `.uproject` file in a text editor to be sure that `EngineAssociation`
 is set to `4.25.3-CSS`.
 
-If Wwise tells you that you need to modify your installation in a yellow warning box, go ahead and follow what it says for this step. If Wwise warns you that it could not find an installation in a red warning box, be sure that you have selected the correct version as stated above. If you see a blue box offering both "Modify" and "Add Plug-in", do nothing and continue to the next step.
+If Wwise tells you that you need to modify your installation in a yellow warning box,
+go ahead and follow what it says for this step.
+If Wwise warns you that it could not find an installation in a red warning box,
+be sure that you have selected the correct version as stated above.
+If you see a blue box offering both "Modify" and "Add Plug-in",
+do nothing and continue to the next step.
 
-Under "Wwise Project Path", click the little triangle dropdown on the right and choose `New` to clear the path.
+Under "Wwise Project Path", click the little triangle dropdown on the right
+and choose `New` to clear the path.
 
-If everything worked according to plan, you should now be able to click on the blue `Integrate` button. Do so, and agree to the terms to start the process.
+If everything worked according to plan,
+you should now be able to click on the blue `Integrate` button.
+Do so, and agree to the terms to start the process.
 
-That's it! If Wwise shows "Operation completed successfully," you have integrated Wwise into your project.
+That's it! If Wwise shows "Operation completed successfully,"
+you have integrated Wwise into your project.
 
 The below gif is slightly outdated - be sure to choose version `2021.1.0.7575`.
 image:BeginnersGuide/simpleMod/Wwise_integrate.gif[image]
@@ -110,9 +124,15 @@ Make sure you run the above command from Command Prompt and not Powershell. It i
 You'll want to compile the project now to ensure it generates correctly.
 
 Do this by opening the .sln file, make sure you have in the toolbar `Development Editor` and `Win64` selected.
-On the right side in solution explorer just r-click the `FactoryGame` project and hit `Build`. This will take some time; go pet some lizard doggos as you wait.
+On the right side in Solution Explorer just right click on
+the `FactoryGame` project and hit `Build`.
+This will take some time; go pet some lizard doggos as you wait.
+You'll know it's done when the little box-with-cubes-piling-into-it
+icon in the blue bar at the bottom of Visual Studio goes away.
+You can monitor its progress from the Output log if desired.
 
-This creates the binaries used by the Editor, allowing it to interact with the native SML code or native code written by you.
+This creates the binaries used by the Editor,
+allowing it to interact with the native SML code or native code written by you.
 
 When you want to test the mod, make sure to build the project for `Shipping`.
 Without doing so, the editor binaries won't be able to dynamic link with their dependencies,
@@ -121,15 +141,26 @@ and the game will crash.
 == Open Unreal Editor
 
 The Unreal Editor allows you to create new content for the game and helps build your mod.
-It also heavily relies on the C++ project, so make sure you don't change stuff in there unless you know what you're doing.
+It also heavily relies on the C++ project,
+so make sure you don't change stuff in there unless you know what you're doing.
 
-In order to open the project in Unreal Engine, you'll have to open the editor. You can find it by searching for it in the Windows search bar (it should appear as Unreal Engine - CSS) or by navigating to where you installed it, which is probably something similar to `C:\Program Files\Unreal Engine - CSS\Engine\Binaries\Win64\UE4Editor.exe`
+In order to open the project in Unreal Engine, you'll have to open the Unreal editor.
+You can find it by searching for it in the Windows search bar
+(it should appear as Unreal Engine - CSS)
+or by navigating to where you installed it,
+which is probably something similar to
+`C:\Program Files\Unreal Engine - CSS\Engine\Binaries\Win64\UE4Editor.exe`
 
 Once the Unreal Engine editor has launched,
-open your project by navigating to `Projects` -> `Browse` (bottom right corner) and selecting the file `FactoryGame.uproject` in your mod folder.
+open your project by navigating to
+`Projects` -> `Browse` (bottom right corner)
+and selecting the file `FactoryGame.uproject` in your mod folder.
 Opening the project for the first time can take a considerable amount of time.
 
-You might be told that some modules were "missing or built with a missing engine version"; press `Yes` and allow it to build. This will take some time, and will drastically increase the size of your mod folder - go find some more lizard doggos to pet.
+You might be told that some modules were
+"missing or built with a missing engine version"; press `Yes` and allow it to build.
+This will take some time, and will drastically increase the size of your mod folder
+- go find some more lizard doggos to pet.
 
 If this step fails, you should go back to
 xref:#_project_compilation[compile the editor from Visual Studio]
@@ -148,8 +179,10 @@ if you haven't taken or dismissed it yet.
 
 == Setting up Alpakit
 
-Alpakit is a tool made by the modding community to make building and testing your mod more convenient.
-Click on the Alpakit button in the Tool-Bar of the Unreal viewport. It looks like an alpaca peeking out of a cardboard box.
+Alpakit is a tool made by the modding community
+to make building and testing your mod more convenient.
+Click on the Alpakit button in the Tool-Bar of the Unreal viewport.
+It looks like an alpaca peeking out of a cardboard box.
 
 Click on the 3 dots near `Satisfactory Game Path`
 and select your root Satisfactory game installation folder.

--- a/modules/ROOT/pages/Development/BeginnersGuide/project_setup.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/project_setup.adoc
@@ -7,8 +7,10 @@ project setup for Satisfactory.
 
 [TIP]
 ====
-If you'd prefer a different format of guide, you can find a video guide https://youtu.be/-HVw6-3Awqs?t=249[here].
-**As of SML 3.0.0, these tutorials are partially out of date, but some of the concepts will still carry over.**
+If you'd prefer a different format of guide, you can find a video guide
+https://youtu.be/-HVw6-3Awqs?t=249[here].
+**As of SML 3.0.0, these tutorials are out of date,
+but some of the concepts will still carry over.**
 If you get stuck in the video tutorials, return here and follow these guides instead.
 Be sure to read over the steps here as well to be sure you're doing things correctly.
 ====

--- a/modules/ROOT/pages/Development/ModLoader/ModModules.adoc
+++ b/modules/ROOT/pages/Development/ModLoader/ModModules.adoc
@@ -59,11 +59,21 @@ which will be automatically registered and bootstrapped regardless of it's name.
 
 [WARNING]
 ====
-If you have more than one module of a type marked as the Root Module,
-SML will purposely crash the game to warn of this mistake.
+It is possible to create more than one module of each the 3 module types
+(Game Instance, Menu World, Game World).
+For example, you could have 2 Game Instance modules,
+1 Game World module, and 1 Menu World module.
 
-If you want to have multiple modules of a type,
-have one root module that calls the other ones.
+However, if you do so, you should only have _one of each type_ marked as the Root Module.
+Otherwise, SML will purposely crash the game to warn of this mistake.
+
+In order to have multiple modules of a type,
+you should have the Root Module that calls the other ones.
+In the earlier example, there would be
+1 Menu World module marked as root,
+1 Game World module marked as root,
+and 1 Game Instance module marked as root
+which calls the second non-root Game Instance module.
 ====
 
 Modules can have submodules they can conditionally load,

--- a/modules/ROOT/pages/Development/TestingResources.adoc
+++ b/modules/ROOT/pages/Development/TestingResources.adoc
@@ -11,13 +11,6 @@ This page will list a couple of helpful resources for testing your mods.
 
 === Instructions
 
-[NOTE]
-====
-This section is a work in progress. It currently just consists of a modified version of
-https://discord.com/channels/555424930502541343/689188183048585244/782335816629223475[this message]
-in the Discord.
-====
-
 Run 2 games of Satisfactory for multiplayer testing in a few easy steps!
 
 1. Create a new Powershell script with the contents of the below 
@@ -33,6 +26,7 @@ and wait for both copies of the game to load.
 and open the console by pressing the ` (backtick/grave) key.
 Then type in `open 127.0.0.1` and hit enter.
 The second instance will now connect to the game hosted by the first instance.
+
 [NOTE]
 ====
 Using backtick to open the console seems to work only with the Windows UK keyboard Layout,
@@ -58,11 +52,11 @@ function BGProcess(){
     Start-Process -NoNewWindow @args
 }
 
-BGProcess "$($GameDir)\FactoryGame\Binaries\Win64\FactoryGame-Win64-Shipping.exe" $Args1
+BGProcess "$($GameDir)\FactoryGame.exe" $Args1
 
 sleep -m 5000
 
-BGProcess "$($GameDir)\FactoryGame\Binaries\Win64\FactoryGame-Win64-Shipping.exe" $Args2
+BGProcess "$($GameDir)\FactoryGame.exe" $Args2
 ----
 
 == Automatically Load a Map on Launch

--- a/modules/ROOT/pages/Development/TestingResources.adoc
+++ b/modules/ROOT/pages/Development/TestingResources.adoc
@@ -29,12 +29,19 @@ and wait for both copies of the game to load.
 
 3. Open up your save file in either copy of the game. 
 
-4. Once you've loaded in, go to the second game instance and open the console by pressing
-Ctrl+Shift+L, then the ` (backtick/grave) key.
-(NOTE: this seems to work only with the Windows UK keyboard Layout,
-not a physical one, but in Windows set it to UK keyboard layout).
+4. Once you've loaded in, go to the second game instance
+and open the console by pressing the ` (backtick/grave) key.
 Then type in `open 127.0.0.1` and hit enter.
 The second instance will now connect to the game hosted by the first instance.
+[NOTE]
+====
+Using backtick to open the console seems to work only with the Windows UK keyboard Layout,
+not a physical one, but in Windows set it to UK keyboard layout.
+On some other keyboard layouts, F2 works instead.
+If you are having trouble opening the console,
+you can edit the settings in Satisfactory's `Input.ini` file
+to change the console key to another key of your choice.
+====
 
 === Powershell Launch Script
 

--- a/modules/ROOT/pages/Development/UpdatingFromOld.adoc
+++ b/modules/ROOT/pages/Development/UpdatingFromOld.adoc
@@ -54,6 +54,13 @@ which has some extra steps if you have a C++ mod.
 * Fill out the fields in your mod's Plugin Manifest
 (which has replaced the `data.json` system).
 
+[WARNING]
+====
+If you have a C++ mod, be sure to specify your Modules correctly
+in the Modules section of the plugin manifest. See the
+xref:UploadToSMR.adoc#_important_c_fields[Uploading to SMR] page for examples
+====
+
 == New Editor Build
 
 You will need to download and install a new copy of the editor build for the new engine from

--- a/modules/ROOT/pages/Development/UpdatingFromOld.adoc
+++ b/modules/ROOT/pages/Development/UpdatingFromOld.adoc
@@ -1,22 +1,5 @@
 = Updating from SML 2.2.1
 
-[WARNING]
-====
-⚠⚠ **ECOSYSTEM IS NOT YET READY FOR MOD DISTRIBUTION TO END USERS** ⚠⚠
-
-SMM and SMR are still being worked on to support new mod distribution format.
-Ficsit.app will not recognize your mod if you try to upload it now!
-You should restrain from distributing your mods publicly now, until the rest of the system is ready.
-
-We will make a public announcement when that happens.
-
-In the mean time, you can **upload your mods the the staging version of SMR**
-as a test, which can be done https://ficsit.dev/[here].
-
-Check the Discord for a special build of SMM that connects to staging SMR
-instead of the live version.
-====
-
 [NOTE]
 ====
 **Save Issue Resolved**

--- a/modules/ROOT/pages/SMLChatCommands.adoc
+++ b/modules/ROOT/pages/SMLChatCommands.adoc
@@ -149,6 +149,8 @@ https://satisfactory.gamepedia.com/[Satisfactory Wiki],
 finding the content on a
 https://github.com/Goz3rr/SatisfactorySaveEditor/tree/master/Reference%20Materials[reference list], or via searching around for it in
 https://www.gildor.org/en/projects/umodel[UModel].
+You can also use it to give yourself additional inventory slots
+via `GiveItemStacks "" numberOfSlots`
 | Resources
 
 |GiveItemsSingle <Blueprint Path> <Number of Items>

--- a/modules/ROOT/pages/UploadToSMR.adoc
+++ b/modules/ROOT/pages/UploadToSMR.adoc
@@ -68,10 +68,6 @@ https://docs.unrealengine.com/en-US/ProductionPipelines/Plugins/index.html#plugi
 or at the {cpp} reference
 https://docs.unrealengine.com/en-US/API/Runtime/Projects/FPluginDescriptor/index.html[here].
 
-If your mod has {cpp} code, make sure that you list a
-UBT Module in the Modules plugin descriptor section.
-The examples below will demonstrate this.
-
 === Special Fields
 
 Note that SML and SMR require you to include additional fields in your plugin descriptor file.
@@ -104,6 +100,7 @@ You can list other mod references (or Unreal Plugins) here,
 and SMM will know to download when installing your mod.
 If you add a plugin with a Mod Reference,
 this basically makes the listed mod a dependency for your mod.
+
 **The SML plugin should also always be listed here,**
 allowing you specify what SML versions your mod supports.
 Each plugin should be listed as an object with the following properties:
@@ -149,6 +146,13 @@ See the Plugins SemVersion item above for the format for this field.
 and can be absent on remote clients altogether.
 
 |===
+
+
+=== Important {cpp} Fields
+
+If your mod has {cpp} code, make sure that you list a
+UBT Module in the Modules plugin descriptor section.
+The examples below will demonstrate this.
 
 
 === Examples

--- a/modules/ROOT/pages/UploadToSMR.adoc
+++ b/modules/ROOT/pages/UploadToSMR.adoc
@@ -72,9 +72,17 @@ If your mod has {cpp} code, make sure that you list a
 UBT Module in the Modules plugin descriptor section.
 The examples below will demonstrate this.
 
+=== Special Fields
+
 Note that SML and SMR require you to include additional fields in your plugin descriptor file.
 
 The most important of these is a mod dependency list and a SemVersion for the mod.
+
+[WARNING]
+====
+Make sure that you have SML listed as an item in the Plugins field,
+as explained below.
+====
 
 Below is a descrption of all extra fields SML and SMR require:
 
@@ -96,7 +104,7 @@ You can list other mod references (or Unreal Plugins) here,
 and SMM will know to download when installing your mod.
 If you add a plugin with a Mod Reference,
 this basically makes the listed mod a dependency for your mod.
-The SML plugin should also always be listed here,
+**The SML plugin should also always be listed here,**
 allowing you specify what SML versions your mod supports.
 Each plugin should be listed as an object with the following properties:
 [cols="1,4a"]
@@ -123,6 +131,11 @@ But if it exists, our mod might be able to unlock more functionality that depend
 For example, regular Unreal Engine plugins your mod requires.
 SMM will not attempt to download these because they aren't mods.
 
+!Enabled
+! This field is not given any extra functionality by SML,
+but we have listed it here as well in order to draw extra attention to it.
+This should be set to `true` in every plugin item.
+
 !===
 
 |RemoteVersionRange
@@ -136,6 +149,9 @@ See the Plugins SemVersion item above for the format for this field.
 and can be absent on remote clients altogether.
 
 |===
+
+
+=== Examples
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/UploadToSMR.adoc
+++ b/modules/ROOT/pages/UploadToSMR.adoc
@@ -174,12 +174,15 @@ Example Blueprint mod .uplugin:
 	"Plugins": [
 		{
 			"Name": "SML",
-			"SemVersion": "^3.0.0"
+			"SemVersion": "^3.0.0",
+			"bIsOptional": false,
+			"Enabled": true
 		},
 		{
 			"Name": "DependingMod",
 			"SemVersion": "^1.3.0",
-			"bIsOptional": false
+			"bIsOptional": false,
+			"Enabled": true
 		}
 	]
 }
@@ -219,12 +222,15 @@ Example {cpp}/Blueprint mod .uplugin:
 	"Plugins": [
 		{
 			"Name": "SML",
-			"SemVersion": "^3.0.0"
+			"SemVersion": "^3.0.0",
+			"bIsOptional": false,
+			"Enabled": true
 		},
 		{
 			"Name": "DependingMod",
 			"SemVersion": "^1.3.0",
-			"bIsOptional": false
+			"bIsOptional": false,
+			"Enabled": true
 		}
 	]
 }

--- a/modules/ROOT/pages/UploadToSMR.adoc
+++ b/modules/ROOT/pages/UploadToSMR.adoc
@@ -96,6 +96,8 @@ You can list other mod references (or Unreal Plugins) here,
 and SMM will know to download when installing your mod.
 If you add a plugin with a Mod Reference,
 this basically makes the listed mod a dependency for your mod.
+The SML plugin should also always be listed here,
+allowing you specify what SML versions your mod supports.
 Each plugin should be listed as an object with the following properties:
 [cols="1,4a"]
 !===
@@ -123,7 +125,26 @@ SMM will not attempt to download these because they aren't mods.
 
 !===
 
+|RemoteVersionRange
+| A Semver range of versions accepted from the remote clients.
+This requires other players to have a certain version of the
+mod installed to be able to join hosts.
+See the Plugins SemVersion item above for the format for this field.
+
+|AcceptsAnyRemoteVersion
+| This should be true if the mod is client/server side only
+and can be absent on remote clients altogether.
+
 |===
+
+[NOTE]
+====
+You can check if your mod's uplugin file is in the correct
+format with the https://ficsit.app/help[validator on the SMR help page]).
+If it fails validation, keep your eyes out for things like missing commas
+and mismatched braces and brackets.
+Consider asking on the Discord if you get stuck on this step.
+====
 
 Some example `.uplugin`s are presented here:
 
@@ -134,7 +155,7 @@ Example Blueprint mod .uplugin:
 {
 	"FileVersion": 3,
 	"Version": 6,
-	"VersionName": "0.2",
+	"VersionName": "0.2.1",
 	"SemVersion": "0.2.1",
 	"FriendlyName": "Example Mod",
 	"Description": "This is a random Blueprint mod.",
@@ -148,7 +169,13 @@ Example Blueprint mod .uplugin:
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,
+	"RemoteVersionRange": "^0.2.1",
+	"AcceptsAnyRemoteVersion": false,
 	"Plugins": [
+		{
+			"Name": "SML",
+			"SemVersion": "^3.0.0"
+		},
 		{
 			"Name": "DependingMod",
 			"SemVersion": "^1.3.0",
@@ -166,7 +193,7 @@ Example {cpp}/Blueprint mod .uplugin:
 {
 	"FileVersion": 3,
 	"Version": 6,
-	"VersionName": "0.2",
+	"VersionName": "0.2.1",
 	"SemVersion": "0.2.1",
 	"FriendlyName": "Example Mod",
 	"Description": "This is a random example C++ and Blueprint mod.",
@@ -180,6 +207,8 @@ Example {cpp}/Blueprint mod .uplugin:
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,
+	"RemoteVersionRange": "^0.2.1",
+	"AcceptsAnyRemoteVersion": false,
 	"Modules": [
 		{
 			"Name": "ExampleMod",
@@ -188,6 +217,10 @@ Example {cpp}/Blueprint mod .uplugin:
 		}
 	],
 	"Plugins": [
+		{
+			"Name": "SML",
+			"SemVersion": "^3.0.0"
+		},
 		{
 			"Name": "DependingMod",
 			"SemVersion": "^1.3.0",

--- a/modules/ROOT/pages/UploadToSMR.adoc
+++ b/modules/ROOT/pages/UploadToSMR.adoc
@@ -68,9 +68,8 @@ https://docs.unrealengine.com/en-US/ProductionPipelines/Plugins/index.html#plugi
 or at the {cpp} reference
 https://docs.unrealengine.com/en-US/API/Runtime/Projects/FPluginDescriptor/index.html[here].
 
-If your mod has {cpp} code, make sure that you list your
-xref:Development/ModLoader/ModModules.adoc[Mod Modules]
-in the Modules plugin descriptor section.
+If your mod has {cpp} code, make sure that you list a
+UBT Module in the Modules plugin descriptor section.
 The examples below will demonstrate this.
 
 Note that SML and SMR require you to include additional fields in your plugin descriptor file.


### PR DESCRIPTION
Notably, removing the "Ecosystem not ready" warning from the Updating from SML2 page, as well as updated info on required fields in uplugin files.