### PR TITLE
Removed the "Adding the Module to the Targets" from the C++ Modding Setup as the step is not needed. Clarified the path in "Creating the Mod-Module" to be created under the Plugin mod folder

### DIFF
--- a/modules/ROOT/pages/Development/Cpp/setup.adoc
+++ b/modules/ROOT/pages/Development/Cpp/setup.adoc
@@ -46,7 +46,7 @@ SF or third party libraries you might want to include.
 == Creating the Mod-Module
 
 To start off, navigate to the base folder of your mod, the location of your `FactoryGame.uproject` and `FactoryGame.sln` files.
-Next, open up the `Source` folder and create a new sub folder, the name of which will be your mod reference.
+Then Navigate to the path 'Plugins/<mod_reference>/' where your '<mod_reference>.uplugin' file is located. Create a new folder named 'Source' inside of which we should create a subfolder, the name of which will be your mod reference.
 As a reminder, the concept of a mod reference is explained xref:Development/BeginnersGuide/index.adoc#_mod_reference[here].
 Within this folder, you should create a new file called `<your mod reference>.Build.cs`.
 You can do this by creating a new text file and then changing the extension to a `.cs` file, for example. If you chose to create the file in this manner, we suggest you turn on https://support.winzip.com/hc/en-us/articles/115011457948-How-to-configure-Windows-to-show-file-extensions-and-hidden-files[showing file name extensions] to assist with this.
@@ -134,27 +134,6 @@ void F<mod reference>Module::StartupModule() {
 
 IMPLEMENT_GAME_MODULE(F<mod_reference>Module, <mod_reference>);
 ----
-
-== Adding the Module to the Targets
-
-Now that you have created your module,
-you will need to add it to the list of default targets so it actually gets built when you run the UBT.
-
-In order to do that, you will need to open the target configurations within the files `/Source/FactoryGame.Target.cs`
-and `/Source/FactoryGameEditor.Target.cs` and make the following changes.
-
-In both of these files, search for
-[source,c#]
-----
-ExtraModuleNames.AddRange( new string[] { "FactoryGame", "SML", "ExampleMod" } );
-----
-(around line 15 in FactoryGame and 11 in FactoryGameEditor)
-and add a string with your mod reference to the array literal like this:
-[source,c#]
-----
-ExtraModuleNames.AddRange( new string[] { "FactoryGame", "SML", "ExampleMod", "mod_reference" } );
-----
-(the mod reference used was `mod_reference`, make sure you use your own mod reference instead)
 
 == Adding the Module to the UProject
 


### PR DESCRIPTION
Removed the "Adding the Module to the Targets" from the C++ Modding Setup as the step is not needed. Clarified the path in "Creating the Mod-Module" to be created under the Plugin mod folder