### PR TITLE
Fix Wwise installation instructions

### DIFF
--- a/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
@@ -74,15 +74,21 @@ Click the download button, which will ask you to sign in.
 Create an account if you don't have one yet, or sign in, to download the launcher.
 After you finished downloading Wwise, open the installer.
 
-Select `WWISE` from the top bar, then press `Install`.
-Once presented with options on what to install,
-make sure that `Authoring` and `SDK (C++)` packages are checked on the left,
-and that `Apple` -> `MacOS` and
-`Microsoft` -> `Windows` -> `Visual Studio 2017`
-and `Visual Studio 2019` are selected, then press `Next`.
-You don't need to add any plugins,
-so just press `Install` to skip in the bottom left to begin the installation process.
-Accept any authentication prompts that appear along the way.
+Select `WWISE` from the top bar.  Click the `Latest` drop-down and change it to `All`.  Select `2021.1` from the next dropdown.  Select version `2021.1.0.7575` from the final dropdown.  Click `Install`.
+Once presented with options on what to install, select:
+
+* Packages
+** Authoring
+** SDK (C++)
+* Deployment Platforms
+** Apple
+*** macOS
+** Microsoft 
+*** Windows
+**** Visual Studio 2017
+**** Visual Studio 2019
+
+Click `Next`.  You don't need to add any plugins so just press `Install` to skip in the bottom left to begin the installation process.  Accept the terms and conditions prompts that appear along the way.
 
 [TIP]
 ====


### PR DESCRIPTION
It looks like the most recent version of Wwise doesn't work if you follow the instructions on the starter project for selecting a specific version.  I needed to install the specific version specified in order to get it to work.  Not 100% positive that is required though.