### PR TITLE
 Fix version number for version branch

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: satisfactory-modding
 title: Satisfactory Modding Documentation
-version: latest
+version: v3.1.1
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
Resolution for error:
#17 0.474 $ antora antora-playbook.yml --clean --fetch
#17 73.54 error: Duplicate nav in latest@satisfactory-modding: modules/ROOT/nav.adoc
#17 73.54   1: modules/ROOT/nav.adoc in https://github.com/satisfactorymodding/Documentation.git (ref: master)
#17 73.54   2: modules/ROOT/nav.adoc in https://github.com/satisfactorymodding/Documentation.git (ref: v3.1.1)