### PR TITLE
move KMods docs to new repo

### DIFF
--- a/antora-playbook-ci.yml
+++ b/antora-playbook-ci.yml
@@ -28,6 +28,11 @@ content:
       edit_url: '{web_url}/blob/{refname}/{path}'
       start_path: docs
 
+    - url: https://gitlab.kmods.de/Kyrium/kbfldocs.git
+      branches: master
+      edit_url: '{web_url}/blob/{refname}/{path}'
+      start_path: docs
+
 ui:
   bundle:
     url: https://gitlab.com/vilsol/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable

--- a/antora-playbook-ci.yml
+++ b/antora-playbook-ci.yml
@@ -29,8 +29,8 @@ content:
       start_path: docs
 
     - url: https://gitlab.kmods.de/Kyrium/kbfldocs.git
-      branches: master
-      edit_url: '{web_url}/blob/{refname}/{path}'
+      branches: main
+      edit_url: '{web_url}/-/blob/{refname}/{path}'
       start_path: docs
 
 ui:

--- a/antora-playbook-ci.yml
+++ b/antora-playbook-ci.yml
@@ -28,9 +28,9 @@ content:
       edit_url: '{web_url}/blob/{refname}/{path}'
       start_path: docs
 
-    - url: https://gitlab.kmods.de/Kyrium/kbfldocs.git
+    - url: https://github.com/Kyri123/KMods-Docs.git
       branches: main
-      edit_url: '{web_url}/-/blob/{refname}/{path}'
+      edit_url: '{web_url}/blob/{refname}/{path}'
       start_path: docs
 
 ui:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -39,9 +39,9 @@ content:
       edit_url: '{web_url}/blob/{refname}/{path}'
       start_path: docs
 
-    - url: https://gitlab.kmods.de/Kyrium/kbfldocs.git
+    - url: https://github.com/Kyri123/KMods-Docs.git
       branches: main
-      edit_url: '{web_url}/-/blob/{refname}/{path}'
+      edit_url: '{web_url}/blob/{refname}/{path}'
       start_path: docs
 
 ui:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -40,8 +40,8 @@ content:
       start_path: docs
 
     - url: https://gitlab.kmods.de/Kyrium/kbfldocs.git
-      branches: master
-      edit_url: '{web_url}/blob/{refname}/{path}'
+      branches: main
+      edit_url: '{web_url}/-/blob/{refname}/{path}'
       start_path: docs
 
 ui:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -39,6 +39,11 @@ content:
       edit_url: '{web_url}/blob/{refname}/{path}'
       start_path: docs
 
+    - url: https://gitlab.kmods.de/Kyrium/kbfldocs.git
+      branches: master
+      edit_url: '{web_url}/blob/{refname}/{path}'
+      start_path: docs
+
 ui:
   bundle:
     url: https://gitlab.com/vilsol/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable


### PR DESCRIPTION
Move the repo because of some SSL problems on hosted GitLab that I cannot solve.