### PR TITLE
.Net Framework Naming

### DIFF
--- a/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
@@ -37,7 +37,7 @@ Continue through the rest of the prompts to install Visual Studio. Downloading a
 
 [WARNING]
 ====
-You will also need the .NET SDK, version 4.6 or higher (but not v5). If you do not know if you have that SDK, the VS installer should provide an option to install it. It is recommended to tick it.
+You will also need the .NET Framework, version 4.6 or higher (but not Core/v5). If you do not know if you have .Net Framework, the VS installer should provide an option to install it. It is recommended to tick it.
 ====
 
 [TIP]


### PR DESCRIPTION
.Net SDKs started with Core and Standard.  They skipped over 4 to avoid confusion with the .Net Framework which is what is needed.  More detail can be seen here https://dotnet.microsoft.com/en-us/download/visual-studio-sdks.  You'll note that Framework is referred to as Runtimes and Developer Packs.  Only the Core line is referred to as SDKs.