### PR TITLE
Add abstract instance to default module dependencies

### DIFF
--- a/modules/ROOT/pages/Development/Cpp/setup.adoc
+++ b/modules/ROOT/pages/Development/Cpp/setup.adoc
@@ -86,7 +86,8 @@ public class <mod_reference> : ModuleRules
             "GameplayTasks",
             "AnimGraphRuntime",
             "Slate", "SlateCore",
-            "Json"
+            "Json",
+	    "AbstractInstance"
             });
 
 


### PR DESCRIPTION
Adds `AbstractInstance` introduced in U7 as default module dependency for setting up C++ modding environment.