### PR TITLE
Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
-	"name": "Node.js",
+	"name": "SML Documentation",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,16 +20,21 @@
 	"postAttachCommand": "yarn serve",
 
 	// Configure tool-specific properties.
-	// "customizations": {},
-
-	"extensions": [
-		"streetsidesoftware.code-spell-checker",
-		"asciidoctor.asciidoctor-vscode",
-		"eamodio.gitlens",
-		"DavidAnson.vscode-markdownlint",
-		"medo64.render-crlf",
-		"andrejunges.Handlebars"
-	]
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"streetsidesoftware.code-spell-checker",
+				"asciidoctor.asciidoctor-vscode",
+				"eamodio.gitlens",
+				"DavidAnson.vscode-markdownlint",
+				"medo64.render-crlf",
+				"andrejunges.Handlebars"
+			],
+			"settings": {
+				"npm.packageManager": "yarn"
+			}
+		}
+	}
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8000],
+
+	// Consistently name the folder so that it can be added as a git safe directory inside the container
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/SML_Documentation,type=bind",
+	"workspaceFolder": "/workspaces/SML_Documentation",
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "git config --global --add safe.directory \"/workspaces/SML_Documentation\"; yarn install",
+	"postAttachCommand": "yarn serve",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	"extensions": [
+		"streetsidesoftware.code-spell-checker",
+		"asciidoctor.asciidoctor-vscode",
+		"eamodio.gitlens",
+		"DavidAnson.vscode-markdownlint",
+		"medo64.render-crlf",
+		"andrejunges.Handlebars"
+	]
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
 				"eamodio.gitlens",
 				"DavidAnson.vscode-markdownlint",
 				"medo64.render-crlf",
-				"andrejunges.Handlebars"
+				"andrejunges.Handlebars",
+				"bierner.markdown-preview-github-styles"
 			],
 			"settings": {
 				"npm.packageManager": "yarn"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 build/
 *.rst
 node_modules/
-antora-playbook-dev.yml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 *.rst
 node_modules/
+!.vscode/tasks.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build:dev",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [],
+			"label": "yarn: build:dev",
+			"detail": "antora antora-playbook-dev.yml"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with questions and suggestions, or contribute via PRs (see below).
 We attempt to use [Semantic Line Break format](https://sembr.org/) in the source files,
 but this is only loosely followed.
 
-Pull requests should target the `dev` branch.
+Pull requests should target the `Dev` branch.
 
 Before you submit changes,
 you should probably follow the Development Setup directions below
@@ -31,6 +31,20 @@ Send us a message on the Discord if we don't review it within a day or two.
 
 ## Development Setup
 
+### Devcontainer
+
+If you already have Visual Studio Code and Docker installed,
+we offer a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers)
+for the repository that will be auto-detected when you open the folder in VSCode.
+
+This should™ also be supported by Github Codespaces, but we haven't tested it.
+
+The container will automatically serve the built content upon opening for preview in your browser or within VSCode.
+
+### Manual
+
+If you don't want to use the preconfigured devcontainer, or Codespaces, follow the directions below.
+
 Although you can edit the `.adoc` files with just about any editor out there,
 we suggest either Visual Studio Code (with the
 [Asciidoc](https://marketplace.visualstudio.com/items?itemName=asciidoctor.asciidoctor-vscode)
@@ -40,7 +54,7 @@ or IntelliJ.
 In order to see what the pages will look like on the live site before being deployed,
 follow the below directions.
 
-### Installing
+#### Installing
 
 1. Install [Node.js](https://nodejs.org/en/download/) and [Yarn Package Manager](https://classic.yarnpkg.com/en/docs/install) through your preferred method
 
@@ -50,7 +64,7 @@ follow the below directions.
 yarn install
 ```
 
-### Building
+#### Building
 
 To build the docs for SML and all other hosted mods (slow):
 
@@ -69,6 +83,12 @@ yarn run build:dev
 ```
 
 The output HTML files for both commands can be found in `\build\site`.
+
+#### Previewing
+
+To preview the content, you can open the output HTML files in your browser, ex. `build/site/satisfactory-modding/latest/index.html`
+
+You can also run `yarn serve` which will start a local webserver.
 
 ## Adding Docs for Another Mod
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Satisfactory Modding Documentation
 
 Documentation for Satisfactory Mod Loader (SML) and Satisfactory modding.
-Master branch is live on https://docs.ficsit.app/.
+Master branch is live on <https://docs.ficsit.app/>.
 Please contact us on the
 [Satisfactory Modding Discord Server](https://discord.gg/xkVJ73E)
 with questions and suggestions, or contribute via PRs (see below).

--- a/antora-playbook-dev.yml
+++ b/antora-playbook-dev.yml
@@ -1,0 +1,27 @@
+site:
+  title: DEV Satisfactory Modding Documentation
+  start_page: satisfactory-modding::index.adoc
+
+  ## Used for dev
+  url: http://localhost:8000
+
+content:
+  sources:
+    # Used for dev
+    - url: ./
+      branches: HEAD
+    
+    # To add additional sites, use the format below
+    # You will probably want to mark this file assume-unchanged in git if so
+    # https://dev.to/nickraphael/git-assume-unchanged-for-when-you-want-git-to-ignore-an-edit-for-a-while-2lig
+
+    #- url: G:\Projects\Satisfactory\Mods\FicsItNetworks
+    #  branches: HEAD
+    #  edit_url: '{web_url}/blob/{refname}/{path}'
+    #  start_path: docs
+
+ui:
+  bundle:
+    url: https://gitlab.com/vilsol/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
+    snapshot: true
+  supplemental_files: ./supplemental-ui

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -71,6 +71,10 @@ The community used to have a Discourse-powered forms website for modding discuss
 but it has since been archived due to low usage.
 You can find the archives https://forums.ficsit.app/[here].
 
+== Contributing
+
+You can find information on how to contribute to the docs https://github.com/satisfactorymodding/Documentation#contributing[in the github repo's readme].
+
 == Modding Technologies
 
 If you'd like to learn more about how modding works internally, this is the section for you.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "antora antora-playbook.yml --clean --fetch",
     "build:ci": "antora antora-playbook-ci.yml --clean --fetch",
-    "build:dev": "antora antora-playbook-dev.yml --clean --fetch",
+    "build:dev": "antora antora-playbook-dev.yml",
     "serve": "ws -d build/site"
   },
   "devDependencies": {


### PR DESCRIPTION
Create a devcontainer to make editing the docs require less setup (assuming the dev has Docker installed)

I think this will also work with Github Codespaces but haven't tested that yet