### PR TITLE
Add shared library steps, better recommended folder structure

### DIFF
--- a/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
+++ b/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
@@ -14,9 +14,6 @@ and `lib/<PlatformName>` containing the compiled library files,
 where `<PlatformName>` is one of the
 https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Programs/UnrealBuildTool/Configuration/UEBuildTarget.cs#L254-L292[Unreal Target Platform names].
 Currently, Satisfactory is released for `Win64` and `Linux`.
-Using `<PlatformName>` makes it easy to handle all the different platforms at once.
-
-Below is an example where all library header files are placed in `inc` and compiled libraries (`.lib`) are placed in `lib/Win64`:
 
 [source,cs]
 ----
@@ -29,7 +26,20 @@ public class <third_party>Library : ModuleRules
     {
         Type = ModuleType.External;
         PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "inc"));
-        PublicLibraryPaths.Add(Path.Combine(ModuleDirectory, "lib", PlatformName));
+
+        var PlatformName = Target.Platform.ToString();
+
+        var LibFolder = Path.Combine(ModuleDirectory, "lib", PlatformName);
+        if (Target.Platform == UnrealTargetPlatform.Win64)
+        {
+            PublicLibraryPaths.Add(Path.Combine(LibFolder, "<third_party1>.lib"));
+            PublicLibraryPaths.Add(Path.Combine(LibFolder, "<third_party2>.lib")); // If the third party library is composed of multiple .lib files
+        }
+        else if (Target.Platform == UnrealTargetPlatform.Linux)
+        {
+            PublicLibraryPaths.Add(Path.Combine(LibFolder, "lib<third_party1>.a"));
+            PublicLibraryPaths.Add(Path.Combine(LibFolder, "lib<third_party2>.a")); // If the third party library is composed of multiple .a files
+        }
     }
 }
 ----
@@ -52,9 +62,6 @@ as they will be allocated with one `new` function on one side, and deallocated w
 Doing so will result in a crash similar to `FMallocBinned2 Attempt to realloc an unrecognized block 0000023E58B80000 canary == 0x0 != 0xe3`
 ====
 
-Below is an example where all library header files are placed in `inc`
-and compiled libraries (`.lib` and `.dll` for Windows, `.a` and `.so` for Linux) are placed in `lib/Win64` and `lib/Linux` respectively:
-
 [source,cs]
 ----
 using System.IO;
@@ -66,9 +73,23 @@ public class <third_party>Library : ModuleRules
     {
         Type = ModuleType.External;
         PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "inc"));
-        PublicLibraryPaths.Add(Path.Combine(ModuleDirectory, "lib", PlatformName));
-        RuntimeDependencies.Add("$(BinaryOutputDir)", Path.Combine(ModuleDirectory, "lib", PlatformName, "*.dll")); // Windows
-        RuntimeDependencies.Add("$(BinaryOutputDir)", Path.Combine(ModuleDirectory, "lib", PlatformName, "*.so")); // Linux
+
+        var PlatformName = Target.Platform.ToString();
+
+        var LibFolder = Path.Combine(ModuleDirectory, "lib", PlatformName);
+        if (Target.Platform == UnrealTargetPlatform.Win64)
+        {
+            PublicLibraryPaths.Add(Path.Combine(LibFolder, "<third_party1>.lib"));
+            PublicLibraryPaths.Add(Path.Combine(LibFolder, "<third_party2>.lib")); // If the third party library is composed of multiple .lib files
+        }
+        else if (Target.Platform == UnrealTargetPlatform.Linux)
+        {
+            PublicLibraryPaths.Add(Path.Combine(LibFolder, "lib<third_party1>.a"));
+            PublicLibraryPaths.Add(Path.Combine(LibFolder, "lib<third_party2>.a")); // If the third party library is composed of multiple .a files
+        }
+
+        RuntimeDependencies.Add("$(BinaryOutputDir)", Path.Combine(LibFolder, "*.dll")); // Windows
+        RuntimeDependencies.Add("$(BinaryOutputDir)", Path.Combine(LibFolder, "*.so")); // Linux
     }
 }
 ----

--- a/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
+++ b/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
@@ -140,3 +140,10 @@ If you are getting errors from compiling the library
 even after wrapping the imports,
 you will need to fix those errors and recompile the library.
 
+== Multiple Mods Using the Same Third Party Library
+
+If you plan to develop multiple mods using the same external library
+you should consider creating a dependency mod to hold the library.
+Although there shouldn't be any issues at runtime if each mod contains the library as a module (untested),
+at development time, Unreal will complain about it when building if both mods are in the project at the same time
+and the third party module name is the same in both.

--- a/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
+++ b/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
@@ -32,13 +32,13 @@ public class <third_party>Library : ModuleRules
         var LibFolder = Path.Combine(ModuleDirectory, "lib", PlatformName);
         if (Target.Platform == UnrealTargetPlatform.Win64)
         {
-            PublicLibraryPaths.Add(Path.Combine(LibFolder, "<third_party1>.lib"));
-            PublicLibraryPaths.Add(Path.Combine(LibFolder, "<third_party2>.lib")); // If the third party library is composed of multiple .lib files
+            PublicAdditionalLibraries.Add(Path.Combine(LibFolder, "<third_party1>.lib"));
+            PublicAdditionalLibraries.Add(Path.Combine(LibFolder, "<third_party2>.lib")); // If the third party library is composed of multiple .lib files
         }
         else if (Target.Platform == UnrealTargetPlatform.Linux)
         {
-            PublicLibraryPaths.Add(Path.Combine(LibFolder, "lib<third_party1>.a"));
-            PublicLibraryPaths.Add(Path.Combine(LibFolder, "lib<third_party2>.a")); // If the third party library is composed of multiple .a files
+            PublicAdditionalLibraries.Add(Path.Combine(LibFolder, "lib<third_party1>.a"));
+            PublicAdditionalLibraries.Add(Path.Combine(LibFolder, "lib<third_party2>.a")); // If the third party library is composed of multiple .a files
         }
     }
 }
@@ -79,13 +79,13 @@ public class <third_party>Library : ModuleRules
         var LibFolder = Path.Combine(ModuleDirectory, "lib", PlatformName);
         if (Target.Platform == UnrealTargetPlatform.Win64)
         {
-            PublicLibraryPaths.Add(Path.Combine(LibFolder, "<third_party1>.lib"));
-            PublicLibraryPaths.Add(Path.Combine(LibFolder, "<third_party2>.lib")); // If the third party library is composed of multiple .lib files
+            PublicAdditionalLibraries.Add(Path.Combine(LibFolder, "<third_party1>.lib"));
+            PublicAdditionalLibraries.Add(Path.Combine(LibFolder, "<third_party2>.lib")); // If the third party library is composed of multiple .lib files
         }
         else if (Target.Platform == UnrealTargetPlatform.Linux)
         {
-            PublicLibraryPaths.Add(Path.Combine(LibFolder, "lib<third_party1>.a"));
-            PublicLibraryPaths.Add(Path.Combine(LibFolder, "lib<third_party2>.a")); // If the third party library is composed of multiple .a files
+            PublicAdditionalLibraries.Add(Path.Combine(LibFolder, "lib<third_party1>.a"));
+            PublicAdditionalLibraries.Add(Path.Combine(LibFolder, "lib<third_party2>.a")); // If the third party library is composed of multiple .a files
         }
 
         RuntimeDependencies.Add("$(BinaryOutputDir)", Path.Combine(LibFolder, "*.dll")); // Windows

--- a/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
+++ b/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
@@ -34,7 +34,28 @@ public class <third_party>Library : ModuleRules
 }
 ----
 
-[source,cpp]
+== Shared (dynamic) libraries
+
+Shared libraries need some additional setup,
+since the runtime linker only looks for shared libraries under the relevant `Binaries/<PlatformName>` folders of Plugins, Mods, and the game.
+
+To have the `.dll` or `.so` files copied from the source folder to `Binaries`,
+you can make use of the `RuntimeDependencies` list of the module.
+This marks files that should be included in the build output of the mod,
+and can additionally copy files to a different location than the original one, which is what you need for shared libraries.
+
+[WARNING]
+====
+Unreal Engine overrides the `new` and `delete` functions, using its custom memory management system,
+Because of this, passing STL objects to/from externally compiled shared libraries is not possible,
+as they will be allocated with one `new` function on one side, and deallocated with an unmatched `delete` function on the other. 
+Doing so will result in a crash similar to `FMallocBinned2 Attempt to realloc an unrecognized block 0000023E58B80000 canary == 0x0 != 0xe3`
+====
+
+Below is an example where all library header files are placed in `inc`
+and compiled libraries (`.lib` and `.dll` for Windows, `.a` and `.so` for Linux) are placed in `lib/Win64` and `lib/Linux` respectively:
+
+[source,cs]
 ----
 using System.IO;
 using UnrealBuildTool;
@@ -45,7 +66,9 @@ public class <third_party>Library : ModuleRules
     {
         Type = ModuleType.External;
         PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "inc"));
-        PublicLibraryPaths.Add(Path.Combine(ModuleDirectory, "x64", "Release"));
+        PublicLibraryPaths.Add(Path.Combine(ModuleDirectory, "lib", PlatformName));
+        RuntimeDependencies.Add("$(BinaryOutputDir)", Path.Combine(ModuleDirectory, "lib", PlatformName, "*.dll")); // Windows
+        RuntimeDependencies.Add("$(BinaryOutputDir)", Path.Combine(ModuleDirectory, "lib", PlatformName, "*.so")); // Linux
     }
 }
 ----

--- a/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
+++ b/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
@@ -8,7 +8,31 @@ You must first create a directory structure that follows this example: `Mods/<mo
 
 The file must contain a class named after the module, and references to any include paths and library paths.
 
-Here is an example where all source files are placed in `inc` and compiled libraries (`.lib`) are placed in `x64/Release`:
+The recommended structure is
+`inc` (or `include`) containing the library header files,
+and `lib/<PlatformName>` containing the compiled library files,
+where `<PlatformName>` is one of the
+https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Programs/UnrealBuildTool/Configuration/UEBuildTarget.cs#L254-L292[Unreal Target Platform names].
+Currently, Satisfactory is released for `Win64` and `Linux`.
+Using `<PlatformName>` makes it easy to handle all the different platforms at once.
+
+Below is an example where all library header files are placed in `inc` and compiled libraries (`.lib`) are placed in `lib/Win64`:
+
+[source,cs]
+----
+using System.IO;
+using UnrealBuildTool;
+
+public class <third_party>Library : ModuleRules
+{
+    public <third_party>Library(ReadOnlyTargetRules Target) : base(Target)
+    {
+        Type = ModuleType.External;
+        PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "inc"));
+        PublicLibraryPaths.Add(Path.Combine(ModuleDirectory, "lib", PlatformName));
+    }
+}
+----
 
 [source,cpp]
 ----

--- a/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
+++ b/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
@@ -1,10 +1,13 @@
 = Third Party Libraries
 
-To add a third party library to your mod, you must add it as a module under your UPlugin.
+Adding third-party {cpp} libaries to your mod is possible but requires some additional setup.
+The third party library must be included as a Module in your mod plugin.
 
 == Module Definition
 
-You must first create a directory structure that follows this example: `Mods/<mod_reference>/Source/ThirdParty/<third_party>Library/` and place a file named after that library in the directory called `<third_party>Library.Build.cs`
+You must first create a directory structure that follows this example:
+`Mods/<mod_reference>/Source/ThirdParty/<third_party>Library/`
+and place a file named after that library in the directory called `<third_party>Library.Build.cs`
 
 The file must contain a class named after the module, and references to any include paths and library paths.
 
@@ -44,7 +47,7 @@ public class <third_party>Library : ModuleRules
 }
 ----
 
-== Shared (dynamic) libraries
+== Shared (Dynamic) Libraries
 
 Shared libraries need some additional setup,
 since the runtime linker only looks for shared libraries under the relevant `Binaries/<PlatformName>` folders of Plugins, Mods, and the game.
@@ -56,7 +59,7 @@ and can additionally copy files to a different location than the original one, w
 
 [WARNING]
 ====
-Unreal Engine overrides the `new` and `delete` functions, using its custom memory management system,
+Unreal Engine overrides the `new` and `delete` functions using its custom memory management system.
 Because of this, passing STL objects to/from externally compiled shared libraries is not possible,
 as they will be allocated with one `new` function on one side, and deallocated with an unmatched `delete` function on the other. 
 Doing so will result in a crash similar to `FMallocBinned2 Attempt to realloc an unrecognized block 0000023E58B80000 canary == 0x0 != 0xe3`
@@ -105,7 +108,8 @@ PublicDependencyModuleNames.AddRange(new string[] {"<third_party>Library"});
 
 == Import Errors
 
-Unreal Engine has stricter standards about what warnings are treated as errors, but some libraries ignore those warnings as they are non-critical to their use case.
+Unreal Engine has stricter standards about what warnings are treated as errors,
+but some libraries ignore those warnings as they are non-critical to their use case.
 
 In those cases, you need to wrap any imports from that library in several layers of compatibility macros and headers.
 
@@ -132,4 +136,7 @@ PRAGMA_POP_PLATFORM_DEFAULT_PACKING
 #include "Windows/HideWindowsPlatformTypes.h"
 ----
 
-If even after wrapping the imports you are getting errors from compiling the library, you will need to fix those errors and recompile the library.
+If you are getting errors from compiling the library
+even after wrapping the imports,
+you will need to fix those errors and recompile the library.
+

--- a/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
+++ b/modules/ROOT/pages/Development/Cpp/thirdparty.adoc
@@ -52,7 +52,7 @@ public class <third_party>Library : ModuleRules
 
 == Module Usage
 
-After you have defined the third party module, you need to reference it in your mod's base module's `<mod_reference>Library.Build.cs` file as a public dependency.
+After you have defined the third party module, you need to reference it in your mod's base module's `<mod_reference>.Build.cs` file as a public dependency.
 
 [source,cpp]
 ----


### PR DESCRIPTION
Based on conversations on discord, with globs so that different `.lib`s and `.dll`s don't need to be individually specified.

~~Changed the recommended folder structure to use the platform names such that you don't need multiple `if`s to handle the different locations of the library binaries.~~ Due to PublicLibraryPaths being removed, individual files need to be added to PublicAdditionalLibraries instead, so separate Windows and Linux handling is still necessary for `.lib` and `.a` files, but `RuntimeDependencies` supports glob, so there's still some benefit to this naming scheme.

Looking for testers for the sample structure and module, as I don't have any third party library to test it on.