### PR TITLE
Fix typo on Access Transformers page

### DIFF
--- a/modules/ROOT/pages/Development/ModLoader/AccessTransformers.adoc
+++ b/modules/ROOT/pages/Development/ModLoader/AccessTransformers.adoc
@@ -53,7 +53,7 @@ This is beneficial when you are trying to access a field and you are not in a cl
 ----
 // Instead of this ...
 SuitCostToUse = Parent->EquipmentParent->mCostToUse;
-// ... use ths
+// ... use this
 SuitCostToUse = Parent->EquipmentParent.GetCostToUse();
 ----
 


### PR DESCRIPTION
Fixed a typo in one of the access transformer examples
![image](https://github.com/satisfactorymodding/Documentation/assets/95051062/82c857a2-928d-40eb-807e-4183dfef93de)