### PR TITLE
AbstractInstance.adoc: Fix typo

### DIFF
--- a/modules/ROOT/pages/Development/Satisfactory/AbstractInstance.adoc
+++ b/modules/ROOT/pages/Development/Satisfactory/AbstractInstance.adoc
@@ -101,7 +101,7 @@ AMyModActor::CreateInstanceFromMesh(UStaticMesh* Mesh) {
 }
 ```
 
-=== Destory Abstract Instances at Runtime
+=== Destroy Abstract Instances at Runtime
 
 ```cpp
 static void RemoveInstances( UObject* WorldContext, TArray<FInstanceHandle*>& Handles, bool bEmptyHandleArray = true );


### PR DESCRIPTION
Change `Destory` to `Destroy`.