### PR TITLE
Add 4netplayers to unsupported providers

### DIFF
--- a/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
+++ b/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
@@ -64,6 +64,7 @@ regardless of what their websites and marketing pages claim:
 - nitroserv.games - Allows creating but not deleting dot files, which bricks the server
 - Shockbyte - Doesn't show the root executable
 - gportal - Doesn't show the proper game file tree, just the Saved folder
+- 4netplayers - Doesn't show the root executable, as well as other game files
 
 It is also worth noting that AMP causes SFTP to throw weird errors, but mods can be installed if pointing SMM to a network mount or local path as described link:#FileTransferMethods_SMB[here].
 


### PR DESCRIPTION
As reported on Discord, this hosting provider doesn't show all files: https://discord.com/channels/555424930502541343/555782140533407764/1240263431085494293

![image](https://github.com/satisfactorymodding/Documentation/assets/22937129/373b9a26-3ad0-4987-b830-99bb36f90f15)
![image](https://github.com/satisfactorymodding/Documentation/assets/22937129/8f2c419a-e88a-4c5b-988b-83e06ab56aa4)
![image](https://github.com/satisfactorymodding/Documentation/assets/22937129/198f3a26-6336-40e1-9fa5-5f6271fe1fe9)
FactoryGame folder:
![image](https://github.com/satisfactorymodding/Documentation/assets/22937129/e77f69ae-9c52-448a-a5b9-df47eb83f2fe)
