### PR TITLE
dependencies.adoc: Add link to UE repo on mirror org

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -7,6 +7,7 @@ exclude = [
     # These will always be 404s unless you're authed
     "https://github.com/satisfactorymodding/UnrealEngine/",
     "https://github.com/EpicGames/UnrealEngine/",
+    "https://github.com/EpicGames-Mirror-A/UnrealEngine/",
     "https://github.com/SatisfactoryModdingUE/UnrealEngine/",
     # Site seems to disallow robots
     "https://cable.ayra.ch/satisfactory/editor.php",

--- a/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
+++ b/modules/ROOT/pages/Development/BeginnersGuide/dependencies.adoc
@@ -136,9 +136,9 @@ You will probably have to check your email and confirm from there,
 as well as making sure you're logged into your linked GitHub account when you follow the upcoming link.
 
 Verify this step has worked by visiting this repository link:
-https://github.com/EpicGames/UnrealEngine/
+https://github.com/EpicGames/UnrealEngine/ (or https://github.com/EpicGames-Mirror-A/UnrealEngine/ since June 2024)
 If it worked, you will see a private GitHub repository
-Close that browser tab - we don't need any files this repository.
+Close that browser tab - we don't need any files from this repository.
 
 [id="UnrealLinker"]
 === Link Your GitHub Account to Our Repository


### PR DESCRIPTION
Beginning on the 10th of June 2024, the Epic Games UE linker adds new users to a different organisation on GitHub, `EpicGames-Mirror-A`. As members of this mirror organisation do not have access to the private repositories from the main `EpicGames` organisation, checking whether the linking process was successful needs to be done using the correct organisation.

Add a link to the mirror organisation's Unreal Engine repository, and specify when this change took place.