### PR TITLE
Drop GTXGaming from unsupported providers

### DIFF
--- a/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
+++ b/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
@@ -52,7 +52,6 @@ regardless of what their websites and marketing pages claim:
 - Shockbyte - Doesn't show the root executable
 - gportal - Doesn't show the proper game file tree. You may have success with manual mod installation, but we offer no support for that process.
 - 4netplayers - Doesn't show the root executable, as well as other game files
-- GTXGaming - Doesn't show the proper game file tree, just the Saved folder
 - Supercraft - Doesn't show the game files, only save files
 
 It is also worth noting that AMP causes SFTP to throw weird errors, but mods can be installed if pointing SMM to a network mount or local path as described link:#FileTransferMethods_SMB[here].


### PR DESCRIPTION
It is now possible to use SMM/ficsit-cli with GTXGaming, so drop them from the list of unsupported providers.