### PR TITLE
Clarify SUBSCRIBE_METHOD_VIRTUAL example

### DIFF
--- a/modules/ROOT/pages/Development/Cpp/hooking.adoc
+++ b/modules/ROOT/pages/Development/Cpp/hooking.adoc
@@ -165,7 +165,8 @@ public:
 #include "Patching/NativeHookManager.h"
 
 void registerHooks() {
-	SUBSCRIBE_METHOD_VIRTUAL(SomeClass::MemberFunction, SomeClass, [](auto& scope, SomeClass* self, int arg1) {
+	auto someClassPtr = GetMutableDefault<SomeClass>();
+	SUBSCRIBE_METHOD_VIRTUAL(SomeClass::MemberFunction, someClassPtr, [](auto& scope, SomeClass* self, int arg1) {
 		// do some nice stuff there
 	});
 

--- a/modules/ROOT/pages/Development/Cpp/hooking.adoc
+++ b/modules/ROOT/pages/Development/Cpp/hooking.adoc
@@ -165,7 +165,7 @@ public:
 #include "Patching/NativeHookManager.h"
 
 void registerHooks() {
-	auto someClassPtr = GetMutableDefault<SomeClass>();
+	SomeClass* someClassPtr = GetMutableDefault<SomeClass>();
 	SUBSCRIBE_METHOD_VIRTUAL(SomeClass::MemberFunction, someClassPtr, [](auto& scope, SomeClass* self, int arg1) {
 		// do some nice stuff there
 	});

--- a/modules/ROOT/pages/Development/Cpp/hooking.adoc
+++ b/modules/ROOT/pages/Development/Cpp/hooking.adoc
@@ -165,8 +165,8 @@ public:
 #include "Patching/NativeHookManager.h"
 
 void registerHooks() {
-	SomeClass* someClassPtr = GetMutableDefault<SomeClass>();
-	SUBSCRIBE_METHOD_VIRTUAL(SomeClass::MemberFunction, someClassPtr, [](auto& scope, SomeClass* self, int arg1) {
+	SomeClass* SampleObject = new SomeClass(); // For UObject derived classes, use SUBSCRIBE_UOBJECT_METHOD instead
+	SUBSCRIBE_METHOD_VIRTUAL(SomeClass::MemberFunction, SampleObject, [](auto& scope, SomeClass* self, int arg1) {
 		// do some nice stuff there
 	});
 


### PR DESCRIPTION
Clarify the SUBSCRIBE_METHOD_VIRTUAL to show that the second arg is a class pointer (as opposed to type name).