### PR TITLE
Remove outdated .Build.cs template

### DIFF
--- a/modules/ROOT/pages/Development/Cpp/setup.adoc
+++ b/modules/ROOT/pages/Development/Cpp/setup.adoc
@@ -74,101 +74,10 @@ to assist with this.
 
 Within this new file you will need to add the following configuration text.
 
-Make sure to replace all instances of `YourModReference` with your actual mod reference.
+Make sure to replace all instances of `PLUGIN_NAME` with your actual mod reference.
 
 The latest version of this template can be found in the
 https://github.com/satisfactorymodding/SatisfactoryModLoader/blob/master/Mods/Alpakit/Templates/CPPAndBlueprintBlank/Source/PLUGIN_NAME/PLUGIN_NAME.Build.cs[Starter Project Repository as an Alpakit template].
-
-// cspell:ignore ISPC
-
-[source,cs]
-----
-using UnrealBuildTool;
-using System.IO;
-using System;
-
-public class YourModReference : ModuleRules
-{
-	public YourModReference(ReadOnlyTargetRules Target) : base(Target)
-	{
-		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-
-		// FactoryGame transitive dependencies
-		// Not all of these are required, but including the extra ones saves you from having to add them later.
-		// Some entries are commented out to avoid compile-time warnings about depending on a module that you don't explicitly depend on.
-		// You can uncomment these as necessary when your code actually needs to use them.
-		PublicDependencyModuleNames.AddRange(new string[] {
-			"Core", "CoreUObject",
-			"Engine",
-			"DeveloperSettings",
-			"PhysicsCore",
-			"InputCore",
-			//"OnlineSubsystem", "OnlineSubsystemUtils", "OnlineSubsystemNull",
-			//"SignificanceManager",
-			"GeometryCollectionEngine",
-			//"ChaosVehiclesCore", "ChaosVehicles", "ChaosSolverEngine",
-			"AnimGraphRuntime",
-			//"AkAudio",
-			"AssetRegistry",
-			"NavigationSystem",
-			//"ReplicationGraph",
-			"AIModule",
-			"GameplayTasks",
-			"SlateCore", "Slate", "UMG",
-			//"InstancedSplines",
-			"RenderCore",
-			"CinematicCamera",
-			"Foliage",
-			//"Niagara",
-			//"EnhancedInput",
-			//"GameplayCameras",
-			//"TemplateSequence",
-			"NetCore",
-			"GameplayTags",
-			"Json", "JsonUtilities",
-			"AssetRegistry"
-		});
-
-		// FactoryGame plugins
-		PublicDependencyModuleNames.AddRange(new string[] {
-			//"AbstractInstance",
-			//"InstancedSplinesComponent",
-			//"SignificanceISPC"
-		});
-
-		// Header stubs
-		PublicDependencyModuleNames.AddRange(new string[] {
-			"DummyHeaders",
-		});
-
-		if (Target.Type == TargetRules.TargetType.Editor) {
-			PublicDependencyModuleNames.AddRange(new string[] {/*"OnlineBlueprintSupport",*/ "AnimGraph"});
-		}
-		PublicDependencyModuleNames.AddRange(new string[] {"FactoryGame", "SML"});
-		
-		PublicIncludePaths.AddRange(new string[] {
-			// ... add public include paths required here ...
-		});
-		
-		PrivateIncludePaths.AddRange(new string[] {
-			// ... add private include paths required here ...
-		});
-		
-		PublicDependencyModuleNames.AddRange(new string[] {
-			// ... add public dependencies that you statically link with here ...
-		});
-		
-		PrivateDependencyModuleNames.AddRange(new string[] {
-			// ... add private dependencies that you statically link with here ...	
-		});
-		
-		DynamicallyLoadedModuleNames.AddRange(new string[] {
-			// ... add any modules that your module loads dynamically here ...
-		});
-	}
-}
-
-----
 
 [WARNING]
 ====


### PR DESCRIPTION
Docs already reference the Alpakit template in the master branch of the SML repo, so there's no need to maintain a copy of the template that is bound to become outdated over time. Also, update the name to replace to `PLUGIN_NAME` as used in the Alpakit template.