### PR TITLE
Remove LOW.MS from unsupported host

### DIFF
--- a/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
+++ b/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
@@ -47,7 +47,6 @@ regardless of what their websites and marketing pages claim:
 
 // cspell:ignore nitroserv gportal
 
-- low.ms - Does not allow executables
 - nitroserv.games - Allows creating but not deleting dot files, which bricks the server
 - Shockbyte - Doesn't show the root executable
 - gportal - Doesn't show the proper game file tree. You may have success with manual mod installation, but we offer no support for that process.


### PR DESCRIPTION
Full Ficsit support is now available with one click install via the control panel. Attached screenshot.

![image](https://github.com/user-attachments/assets/729d202e-81f9-4c31-b270-38e9962e721d)
