### PR TITLE
Add 3rd party hosting services to allowed mods section

### DIFF
--- a/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
+++ b/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
@@ -64,7 +64,9 @@ const unshuffled = [
   "Nitrado",
   "GTX Gaming",
   "Nodecraft",
-  "Gravel Host"
+  "Gravel Host",
+  "dawnserver.de,
+  "gameserver.gamed.de"
 ];
 const shuffled = unshuffled
   .map(value => ({ value, sort: Math.random() }))
@@ -88,7 +90,6 @@ regardless of what their websites and marketing pages claim:
 - nitroserv.games - Allows creating but not deleting dot files, which bricks the server
 - Shockbyte - Doesn't show the root executable
 - 4netplayers - Doesn't show the root executable, as well as other game files
-- dawnserver.de - Provider does not allow mods
 ====
 
 ====


### PR DESCRIPTION
I already had Satisfactory servers with these two newly added providers. Mods were allowed and could be installed here.