### PR TITLE
Update DedicatedServerSetup.adoc with hosting details

### DIFF
--- a/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
+++ b/modules/ROOT/pages/ForUsers/DedicatedServerSetup.adoc
@@ -58,6 +58,7 @@ The below list is shuffled each time the page is loaded to avoid bias towards an
 <script>
 const unshuffled = [
   "Indifferent Broccoli",
+  "Shockbyte",
   "Bisect Hosting",
   "Zap Hosting",
   "Supercraft",
@@ -86,7 +87,6 @@ regardless of what their websites and marketing pages claim:
 
 // cspell:ignore nitroserv gportal
 - nitroserv.games - Allows creating but not deleting dot files, which bricks the server
-- Shockbyte - Doesn't show the root executable
 - 4netplayers - Doesn't show the root executable, as well as other game files
 - dawnserver.de - Provider does not allow mods
 ====


### PR DESCRIPTION
This update removes the line stating “Shockbyte - Doesn’t show the root executable” and adds Shockbyte to the supported server hosting list.

We recently made a few changes on Shockbyte’s end and tested the Satisfactory Mod Manager; everything now works 100% as expected.